### PR TITLE
Add std_compat to build for LibPressio

### DIFF
--- a/libpressio_install.sh
+++ b/libpressio_install.sh
@@ -18,6 +18,7 @@ git clone https://github.com/CODARcode/MGARD
 git clone https://github.com/facebook/zstd
 git clone https://github.com/szcompressor/SZ
 git clone https://github.com/LLNL/zfp
+git clone https://github.com/robertu94/std_compat
 git clone https://github.com/CODARcode/libpressio
 
 mkdir -p zstd/builddir
@@ -50,6 +51,13 @@ make -j
 make install
 popd
 ln -s $rootDir/compressor-install/ $rootDir/MGARD/MGARD-install
+
+mkdir -p std_compat/build
+pushd std_compat/build
+cmake .. -DCMAKE_INSTALL_PREFIX=$rootDir/compressor-install -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_TESTING=OFF
+make -j
+make install
+popd
 
 LIBPRESSIO_CMAKE_ARGS="-DCMAKE_INSTALL_PREFIX=$rootDir/compressor-install -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_LIBDIR=lib"
 mkdir -p libpressio/build

--- a/libpressio_install.sh
+++ b/libpressio_install.sh
@@ -15,9 +15,17 @@ git clone https://github.com/CODARcode/MGARD
 #git checkout 8a1e16949d8ceee881d16e245ea262bd2d924609
 #cd -
 
-git clone http://github.com/disheng222/SZ
-git clone http://github.com/LLNL/zfp
+git clone https://github.com/facebook/zstd
+git clone https://github.com/szcompressor/SZ
+git clone https://github.com/LLNL/zfp
 git clone https://github.com/CODARcode/libpressio
+
+mkdir -p zstd/builddir
+pushd zstd/builddir
+cmake ../build/cmake/ -DCMAKE_INSTALL_PREFIX=$rootDir/compressor-install -DCMAKE_INSTALL_LIBDIR=lib
+make -j
+make install
+popd
 
 mkdir -p SZ/build
 pushd SZ/build

--- a/libpressio_update.sh
+++ b/libpressio_update.sh
@@ -22,7 +22,24 @@ if [[ ! -d zstd ]]; then
   pushd zstd/builddir
   cmake ../build/cmake/ -DCMAKE_INSTALL_PREFIX=$rootDir/compressor-install -DCMAKE_INSTALL_LIBDIR=lib
   popd
+elif
+  pushd zstd/builddir
+  make
+  popd
 fi
+
+if [[ ! -d std_compat ]]; then
+  git clone https://github.com/robertu94/std_compat
+  mkdir -p std_compat/build
+  pushd std_compat/build
+  cmake .. -DCMAKE_INSTALL_PREFIX=$rootDir/compressor-install -DCMAKE_INSTALL_LIBDIR=lib
+  popd
+elif
+  pushd std_compat/build
+  make
+  popd
+fi
+
 
 pushd SZ/builddir
 git pull

--- a/libpressio_update.sh
+++ b/libpressio_update.sh
@@ -15,6 +15,23 @@ git pull
 #git checkout 8a1e16949d8ceee881d16e245ea262bd2d924609
 cd -
 
+
+if [[ ! -d zstd ]]; then
+  git clone https://github.com/facebook/zstd
+  mkdir -p zstd/builddir
+  pushd zstd/builddir
+  cmake ../build/cmake/ -DCMAKE_INSTALL_PREFIX=$rootDir/compressor-install -DCMAKE_INSTALL_LIBDIR=lib
+  popd
+fi
+
+pushd SZ/builddir
+git pull
+make -j
+make install
+popd
+
+
+
 mkdir -p SZ/build
 pushd SZ/build
 git pull

--- a/mgard-patches/mgarddouble_CompDecomp.c
+++ b/mgard-patches/mgarddouble_CompDecomp.c
@@ -1,8 +1,6 @@
 #include <libpressio.h>
 #include <libpressio_ext/io/posix.h>
-#include <mgard.h>
 
-#include "make_input_data.h"
 #include "zc.h"
 
 size_t computeDataLength(size_t r5, size_t r4, size_t r3, size_t r2, size_t r1, int* dim)

--- a/mgard-patches/mgardfloat_CompDecomp.c
+++ b/mgard-patches/mgardfloat_CompDecomp.c
@@ -1,8 +1,6 @@
 #include <libpressio.h>
 #include <libpressio_ext/io/posix.h>
-#include <mgard.h>
 
-#include "make_input_data.h"
 #include "zc.h"
 
 size_t computeDataLength(size_t r5, size_t r4, size_t r3, size_t r2, size_t r1, int* dim)


### PR DESCRIPTION
Fixes build for future versions of LibPressio which require std_compat.